### PR TITLE
ci: switch releases to be own by Lacework releng ⚡

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
       - checkout
       - add_ssh_keys:
           fingerprints:
-            - "dd:e0:c0:f6:be:62:ea:e2:91:1f:51:eb:36:5f:90:90"
+            - "42:6e:97:1d:59:f6:82:68:aa:ac:e5:a6:2d:33:93:63"
       - run: scripts/release.sh trigger
   release:
     executor: alpine

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<a href="https://lacework.com"><img src="https://techally-content.s3-us-west-1.amazonaws.com/public-content/lacework_logo_full.png" width="200"></a>
+<a href="https://lacework.com"><img src="https://techally-content.s3-us-west-1.amazonaws.com/public-content/lacework_logo_full.png" width="600"></a>
 
 # terraform-kubernetes-agent
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -10,8 +10,8 @@ set -eou pipefail
 
 readonly org_name=lacework
 readonly project_name=terraform-kubernetes-agent
-readonly git_user="Alan Nix"
-readonly git_email="alan.nix@lacework.net"
+readonly git_user="Lacework Inc."
+readonly git_email="ops+releng@lacework.net"
 VERSION=$(cat VERSION)
 
 usage() {


### PR DESCRIPTION
As a Lacework Engineer, 
I would like to use an in-house Github account to set up all releases and pipelines
So I don't have to use my personal Github account.

## Description
We are starting to use the company's Github account https://github.com/lacework-releng to do
our automated releases.

Signed-off-by: Salim Afiune Maya <afiune@lacework.net>