### PR TITLE
feat: Support setting ServiceAccount in Pod template

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The `main.tf` file will configure a Kubernetes Secret and DaemonSet which will t
 | lacework_image | The name of the image to use for deploying the Lacework datacollector | `string` | "lacework/datacollector" |
 | lacework_image_pull_policy | The pull policy to use for deploying the Lacework datacollector | `string` | "Always" |
 | namespace | The Kubernetes namespace in which to deploy | `string` | "default" |
+| pod_service_account | The Kubernetes ServiceAccount to use in the pod template | `string` | "" |
 | pod_cpu_request | The amount of CPU units to request for the Lacework datacollector pod | `string` | "100m" |
 | pod_mem_request | The amount of Memory to request for the Lacework datacollector pod | `string` | "512Mi" |
 | pod_cpu_limit | The limit of CPU units for the Lacework datacollector pod | `string` | "1" |

--- a/main.tf
+++ b/main.tf
@@ -66,6 +66,8 @@ resource "kubernetes_daemonset" "lacework_datacollector" {
           }
         }
 
+        service_account_name = var.pod_service_account
+
         container {
           name              = "lacework"
           image             = var.lacework_image

--- a/variables.tf
+++ b/variables.tf
@@ -45,6 +45,12 @@ variable "namespace" {
   default     = "default"
 }
 
+variable "pod_service_account" {
+  type        = string
+  description = "The Kubernetes ServiceAccount to use in the pod template"
+  default     = ""
+}
+
 variable "pod_cpu_request" {
   type        = string
   default     = "100m"


### PR DESCRIPTION
This is useful in clusters where PodSecurityPolicies are used, to assign a more permissive PSP to the Lacework agent.