### PR TITLE
Fixing app label missing from pods

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -48,6 +48,7 @@ resource "kubernetes_daemonset" "lacework_datacollector" {
       metadata {
         labels = {
           name = "lacework"
+          app  = var.lacework_agent_name
         }
 
         annotations = {


### PR DESCRIPTION
Adding 'app' lace as lacework agent name to pods. 