### PR TITLE
fix: added support for "special case" tolerations

### DIFF
--- a/examples/custom-tolerations/main.tf
+++ b/examples/custom-tolerations/main.tf
@@ -16,6 +16,13 @@ module "lacework_k8s_datacollector" {
       key      = "spotInstance",
       operator = "Exists",
       effect   = "NoSchedule"
+    },
+    {
+      operator = "Exists",
+      effect   = "NoSchedule"
+    },
+    {
+      operator = "Exists"
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -64,10 +64,10 @@ resource "kubernetes_daemonset" "lacework_datacollector" {
         dynamic "toleration" {
           for_each = var.tolerations
           content {
-            key      = toleration.value["key"]
+            key      = lookup(toleration.value, "key", "")
             operator = lookup(toleration.value, "operator", "Equal")
             value    = lookup(toleration.value, "operator", "Equal") == "Exists" ? "" : lookup(toleration.value, "value", "")
-            effect   = toleration.value["effect"]
+            effect   = lookup(toleration.value, "effect", "")
           }
         }
 


### PR DESCRIPTION
***Description:***
Added support for special case Tolerations

***Additional Info:***
There are two special cases:
- An empty `key` with operator `Exists` matches all keys, values and effects which means this will tolerate everything.
- An empty `effect` matches all effects with key `key`.

