### PR TITLE
feat: add autoupgrade flag and enable stdout logging

### DIFF
--- a/config.tmpl
+++ b/config.tmpl
@@ -2,6 +2,7 @@
     "tokens": {
         "AccessToken": "${lacework_access_token}"
     },
+    %{ if ! lacework_agent_autoupgrade }"autoupgrade": "disable",%{ endif }
     %{ if lacework_agent_interface_connection_size != "" }"InterfaceConnectionSize": "${lacework_agent_interface_connection_size}",%{ endif }
     %{ if lacework_proxy_url != "" }"proxyurl": "${lacework_proxy_url}",%{ endif }
     %{ if lacework_server_url != "" }"serverurl": "${lacework_server_url}",%{ endif }

--- a/examples/custom-upgrade-behavior/README.md
+++ b/examples/custom-upgrade-behavior/README.md
@@ -1,0 +1,15 @@
+# Kubernetes Deployment w/ Autoupgrade Disabled
+
+This example shows how to disable the autoupgrade functionality of the Lacework Agent.
+
+```hcl
+provider "kubernetes" {}
+
+module "lacework_k8s_datacollector" {
+  source = "lacework/agent/kubernetes"
+  version = "~> 1.0"
+
+  lacework_access_token      = "0123456789ABCDEF0123456789ABCDEF"
+  lacework_agent_autoupgrade = false
+}
+```

--- a/examples/custom-upgrade-behavior/main.tf
+++ b/examples/custom-upgrade-behavior/main.tf
@@ -1,0 +1,8 @@
+provider "kubernetes" {}
+
+module "lacework_k8s_datacollector" {
+  source = "../../"
+
+  lacework_access_token      = "0123456789ABCDEF0123456789ABCDEF"
+  lacework_agent_autoupgrade = false
+}

--- a/main.tf
+++ b/main.tf
@@ -78,6 +78,11 @@ resource "kubernetes_daemonset" "lacework_datacollector" {
           image             = var.lacework_image
           image_pull_policy = var.lacework_image_pull_policy
 
+          env {
+            name  = "LaceworkLogStdout"
+            value = "yes"
+          }
+
           resources {
             requests = {
               cpu    = var.pod_cpu_request

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   config_data = templatefile("${path.module}/config.tmpl", {
     lacework_access_token                    = var.lacework_access_token,
+    lacework_agent_autoupgrade               = var.lacework_agent_autoupgrade
     lacework_agent_interface_connection_size = var.lacework_agent_interface_connection_size
     lacework_agent_tags                      = jsonencode(merge({ "Env" : "k8s" }, var.lacework_agent_tags))
     lacework_proxy_url                       = var.lacework_proxy_url

--- a/scripts/ci_tests.sh
+++ b/scripts/ci_tests.sh
@@ -14,6 +14,7 @@ TEST_CASES=(
   examples/custom-resource-allocation
   examples/custom-server-url
   examples/custom-tolerations
+  examples/custom-upgrade-behavior
   examples/default
 )
 

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "lacework_agent_tags" {
   default     = {}
 }
 
+variable "lacework_agent_autoupgrade" {
+  type        = bool
+  description = "Boolean value to control whether or not the agent should automatically upgrade to newer versions when available"
+  default     = true
+}
+
 variable "lacework_config_name" {
   type        = string
   description = "The name for the Lacework agent configuration within Kubernetes"


### PR DESCRIPTION
This PR adds a flag to control the agent's autoupgrade behavior, as well
as enabling agent logging to stdout. This matches the behavior of the
Helm charts.