### PR TITLE
chore(example): add more custom agent config

### DIFF
--- a/examples/custom-agent-configuration/main.tf
+++ b/examples/custom-agent-configuration/main.tf
@@ -5,6 +5,10 @@ module "lacework_k8s_datacollector" {
 
   lacework_access_token = "0123456789ABCDEF0123456789ABCDEF"
   lacework_agent_configuration = {
+    "fim" = {
+      "runat" : "23:50"
+      "mode" : "enable"
+    }
     "privileges" : {
       "capsmode" : "enabled"
     }


### PR DESCRIPTION
## Summary

Users are having issues understanding how to add multiple fields to the `lacework_agent_configuration`
variable so I have added more custom config to it.

## How did you test this change?

CI should be green.

## Issue

N/A
