### PR TITLE
fix: lacework_agent_configuration type

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -34,7 +34,7 @@ variable "lacework_agent_autoupgrade" {
 }
 
 variable "lacework_agent_configuration" {
-  type        = map(any)
+  type        = any
   description = "A map/dictionary of configuration parameters for the Lacework datacollector"
   default     = {}
 }


### PR DESCRIPTION
## Summary

```The keyword map is a shorthand for map(any), which accepts any element type as long as every element is the same type. This is for compatibility with older configurations; for new code, we recommend using the full form.```

Need to change variable type of lacework_agent_configuration from a collectionType to a structuralType.  This means defining specific object attributes.

My best attempt at finding documented agent configuration [Configure Linux Agent Behavior in config.json File | Lacework Documentation](https://docs.lacework.com/onboarding/configure-agent-behavior-in-configjson-file).  And what looks to actually be supported.  Even the [TF examples](https://github.com/lacework/terraform-kubernetes-agent/tree/main/examples/custom-agent-configuration) contains an undocumented variable `privileges`.

Therefore I am proposing changing the type to `any`.

## How did you test this change?

Local testing with `terraform validate` and `terraform plan`.

Example `main.tf` attached to Jira ticket.

## Issue

[LINK-1111](https://lacework.atlassian.net/browse/LINK-1111)
