### PR TITLE
feat: add the ability to change node affinity

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ No modules.
 | <a name="input_lacework_proxy_url"></a> [lacework\_proxy\_url](#input\_lacework\_proxy\_url) | The proxy URL for the Lacework agent | `string` | `""` | no |
 | <a name="input_lacework_server_url"></a> [lacework\_server\_url](#input\_lacework\_server\_url) | The server URL for the Lacework agent | `string` | `""` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | The Kubernetes namespace in which to deploy | `string` | `"default"` | no |
+| <a name="input_node_affinity"></a> [node\_affinity](#input\_node\_affinity) | Node affinity settings | <pre>list(object({<br>    key      = string<br>    operator = string<br>    values   = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "key": "kubernetes.io/arch",<br>    "operator": "In",<br>    "values": [<br>      "amd64",<br>      "arm64"<br>    ]<br>  },<br>  {<br>    "key": "kubernetes.io/os",<br>    "operator": "In",<br>    "values": [<br>      "linux"<br>    ]<br>  }<br>]</pre> | no |
 | <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | A map of key:value pairs of node labels to specify which nodes to deploy the DaemonsSet to | `map(any)` | `null` | no |
 | <a name="input_pod_cpu_limit"></a> [pod\_cpu\_limit](#input\_pod\_cpu\_limit) | The limit of CPU units for the Lacework datacollector pod | `string` | `"500m"` | no |
 | <a name="input_pod_cpu_request"></a> [pod\_cpu\_request](#input\_pod\_cpu\_request) | The amount of CPU units to request for the Lacework datacollector pod | `string` | `"200m"` | no |

--- a/lacework_node.tf
+++ b/lacework_node.tf
@@ -91,25 +91,17 @@ resource "kubernetes_daemonset" "lacework_datacollector" {
       }
 
       spec {
-
         affinity {
           node_affinity {
             required_during_scheduling_ignored_during_execution {
-              node_selector_term {
-                match_expressions {
-                  key      = "kubernetes.io/arch"
-                  operator = "In"
-                  values = [
-                    "amd64",
-                    "arm64"
-                  ]
-                }
-                match_expressions {
-                  key      = "kubernetes.io/os"
-                  operator = "In"
-                  values = [
-                    "linux"
-                  ]
+              dynamic "node_selector_term" {
+                for_each = var.node_affinity
+                content {
+                  match_expressions {
+                    key      = node_selector_term.value.key
+                    operator = node_selector_term.value.operator
+                    values   = node_selector_term.value.values
+                  }
                 }
               }
             }

--- a/variables.tf
+++ b/variables.tf
@@ -215,3 +215,30 @@ variable "node_selector" {
   default     = null
   description = "A map of key:value pairs of node labels to specify which nodes to deploy the DaemonsSet to"
 }
+
+variable "node_affinity" {
+  description = "Node affinity settings"
+
+  type = list(object({
+    key      = string
+    operator = string
+    values   = list(string)
+  }))
+
+  default = [
+    {
+      key      = "kubernetes.io/arch",
+      operator = "In",
+      values = [
+        "amd64",
+        "arm64"
+    ] },
+    {
+      key      = "kubernetes.io/os",
+      operator = "In",
+      values = [
+        "linux"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

We are running a mixed environment (ec2 / fargate) and would like to add a node anti-affinity for the fargate nodes

```              
- key: eks.amazonaws.com/compute-type
  operator: NotIn
  values:
    - fargate
```

